### PR TITLE
[cli] fix init starter yaml formatting problem

### DIFF
--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -4,6 +4,7 @@
 import fs from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
+import {ProjectManifest} from '@subql/common';
 import yaml from 'js-yaml';
 import rimraf from 'rimraf';
 import simpleGit from 'simple-git';
@@ -52,7 +53,7 @@ async function prepareManifest(projectPath: string, project: ProjectSpec): Promi
   //load and write manifest(project.yaml)
   const yamlPath = path.join(`${projectPath}`, `project.yaml`);
   const manifest = await fs.promises.readFile(yamlPath, 'utf8');
-  const data = yaml.safeLoadAll(manifest)[0];
+  const data = yaml.safeLoad(manifest) as ProjectManifest;
   data.description = project.description ?? data.description;
   data.network.endpoint = project.endpoint;
   data.repository = project.repository ?? '';

--- a/packages/cli/src/controller/init-controller.ts
+++ b/packages/cli/src/controller/init-controller.ts
@@ -52,10 +52,10 @@ async function prepareManifest(projectPath: string, project: ProjectSpec): Promi
   //load and write manifest(project.yaml)
   const yamlPath = path.join(`${projectPath}`, `project.yaml`);
   const manifest = await fs.promises.readFile(yamlPath, 'utf8');
-  const data = yaml.safeLoadAll(manifest);
-  data[0].description = project.description ?? data[0].description;
-  data[0].network.endpoint = project.endpoint;
-  data[0].repository = project.repository ?? '';
+  const data = yaml.safeLoadAll(manifest)[0];
+  data.description = project.description ?? data.description;
+  data.network.endpoint = project.endpoint;
+  data.repository = project.repository ?? '';
   const newYaml = yaml.safeDump(data);
   await fs.promises.writeFile(yamlPath, newYaml, 'utf8');
 }


### PR DESCRIPTION
Command init starter generate project manifest format is problematic,  yarn codegen will throw error when access the yaml.
This fix the output manifest format. 