### PR TITLE
fix query.system.lastRuntimeUpgrade return null before the first runtime upgrade

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
     - name: build
       run: yarn workspaces foreach run build
     - name: code-style check
-      run: yarn pretty-quick --check --pattern 'packages/*/src/**/*'
+      run: yarn pretty-quick --check --pattern 'packages/*/src/**/*' --branch main
     - name: lint
       run: yarn lint
     - name: test


### PR DESCRIPTION
use rpc.state.getRuntimeVersion instead